### PR TITLE
provisioning-registration-war version fixed

### DIFF
--- a/geo-publisher-services/pom.xml
+++ b/geo-publisher-services/pom.xml
@@ -84,7 +84,7 @@
 			<dependency>
 				<groupId>nl.idgis.sys</groupId>
 				<artifactId>provisioning-registration-war</artifactId>
-				<version>0.2.0</version>
+				<version>${project.parent.version}</version>
 				<type>war</type>
 			</dependency>
 			


### PR DESCRIPTION
should always be the same version as the other stuff from nl.idgis.sys
