### PR TITLE
jndi resource properties added

### DIFF
--- a/geo-publisher-services/geo-publisher-geoserver/src/main/docker/start.sh
+++ b/geo-publisher-services/geo-publisher-geoserver/src/main/docker/start.sh
@@ -40,7 +40,12 @@ echo \
 		"driverClassName=\"org.postgresql.Driver\" "\
 		"url=\"jdbc:postgresql://db:5432/publisher\" "\
 		"username=\"$PG_USER\" "\
-		"password=\"$PG_PASSWORD\" />"\
+		"password=\"$PG_PASSWORD\" "\
+		"defaultAutoCommit=\"false\" "\
+		"rollbackOnReturn=\"true\" "\
+		"testOnBorrow=\"true\" "\
+		"validationInterval=\"0\" "\
+	"/>"\
 "</Context>" > /var/lib/tomcat7/conf/Catalina/localhost/$PUBLISHER_GEOSERVER_NAME.xml
 
 exec /usr/share/tomcat7/bin/catalina.sh run


### PR DESCRIPTION
'defaultAutoCommit' and 'rollbackOnReturn' are required to guarantee
that database transactions are always properly terminated.

'testOnBorrow' and 'validationInterval' ensure that invalidated
connections (e.g. because the tcp session was terminated) are removed
from the connection pool.
